### PR TITLE
use setuptools

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <settings>
-    <option name="USE_PROJECT_PROFILE" value="false" />
+    <option name="PROJECT_PROFILE" value="Project Default" />
+    <option name="USE_PROJECT_PROFILE" value="true" />
     <version value="1.0" />
   </settings>
 </component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
-    <option name="PROJECT_PROFILE" value="Project Default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
+    <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>
 </component>

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python2
 
-from distutils.core import setup
+from setuptools import setup
+
 import bayesian_changepoint_detection
 
-setup(name='bayesian_changepoint_detection',
-      version=bayesian_changepoint_detection.__version__,
-      description='Some Bayesian changepoint detection algorithms',
-      author='Johannes Kulick',
-      author_email='johannes.kulick@ipvs.uni-stuttgart.de',
-      url='http://github.com/hildensia/bayesian_changepoint_detection',
-      packages = ['bayesian_changepoint_detection'],
-      install_requires=['scipy', 'numpy']
-     )
+setup(
+    name='bayesian_changepoint_detection',
+    version=bayesian_changepoint_detection.__version__,
+    description='Some Bayesian changepoint detection algorithms',
+    author='Johannes Kulick',
+    author_email='johannes.kulick@ipvs.uni-stuttgart.de',
+    url='http://github.com/hildensia/bayesian_changepoint_detection',
+    packages=['bayesian_changepoint_detection'],
+    install_requires=['scipy', 'numpy']
+)

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(name='bayesian_changepoint_detection',
       author_email='johannes.kulick@ipvs.uni-stuttgart.de',
       url='http://github.com/hildensia/bayesian_changepoint_detection',
       packages = ['bayesian_changepoint_detection'],
-      requires=['scipy', 'numpy']
+      install_requires=['scipy', 'numpy']
      )


### PR DESCRIPTION
The current setup.py doesn't actually install its requirements, because it uses the out of date distutils specification rather than setuptools. To be honest setup.py is being replaced by setup.cfg anyway, but I figured I might as well make this small improvement in the meantime
