### PR TITLE
CD automation for deployment to PyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,44 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: CD
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+## Prod PyPI
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PROD_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*
+
+## Test PyPI
+#    - name: Build and publish
+#      env:
+#        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+#        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_PASSWORD }}
+#      run: |
+#        python setup.py sdist bdist_wheel
+#        twine upload --repository testpypi dist/*

--- a/bayesian_changepoint_detection/__init__.py
+++ b/bayesian_changepoint_detection/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python2
 
-__version__ = '0.3'
+__version__ = '0.4'


### PR DESCRIPTION
What is this feature about? 
CD for deploying package to PyPI. 
It makes use of Github's workflow. 

Closes Issues: https://github.com/hildensia/bayesian_changepoint_detection/issues/32 

Pre-req for owner @hildensia before merging this : 
1. Create a new API tokens inside your PyPI account where this project lives https://pypi.org/ 
2. Creating two Repository secrets inside the github project setting. ([Steps defined here](https://docs.github.com/en/actions/security-guides/encrypted-secrets))
A. Secret name `PYPI_USERNAME` which value `__token__`  
B. Secret name `PYPI_PROD_PASSWORD` with the token value from `step #1` 

How to release a package? 
[Leveraging github release feature](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
This can only be done by project admin/maintainer. @hildensia 
Right now have made the release to based on manual action. We have to make use the of `Releases` option shown by github, provide a version tag number and description. 
If we want to change the release strategy we can update the cd.yml accordingly but usually I have seen projects follow manual release. 

What Testing was done?
I have tested this pipeline where the package was deployed to my Test PyPI account. 
https://github.com/zillow/bayesian_changepoint_detection/actions/runs/1966108484 